### PR TITLE
Add WAVE icons to solution page headings

### DIFF
--- a/docs/known-issues-and-solutions/solutions-index/alert-a-nearby-image-has-the-same-alternative-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-a-nearby-image-has-the-same-alternative-text.md
@@ -1,4 +1,4 @@
-# Alert - A nearby image has the same alternative text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/alt_duplicate.svg" /> Alert - A nearby image has the same alternative text
 - WAVE Category: Alert
 - WAVE Alert: A nearby image has the same alternative text
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-accesskey.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-accesskey.md
@@ -1,4 +1,4 @@
-# Alert - Accesskey
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/accesskey.svg" /> Alert - Accesskey
 - WAVE Category: Alert
 - WAVE Alert: Accesskey
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-audio-video.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-audio-video.md
@@ -1,4 +1,4 @@
-# Alert - Audio/Video
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/audio_video.svg" /> Alert - Audio/Video
 - WAVE Category: Alert
 - WAVE Alert: Audio/Video
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-broken-same-page-link.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-broken-same-page-link.md
@@ -1,4 +1,4 @@
-# Alert - Broken same-page link
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_internal_broken.svg" /> Alert - Broken same-page link
 - WAVE Category: Alert
 - WAVE Alert: Broken same-page link
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-device-dependent-event-handler.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-device-dependent-event-handler.md
@@ -1,4 +1,4 @@
-# Alert - Device dependent event handler
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/event_handler.svg" /> Alert - Device dependent event handler
 - WAVE Category: Alert
 - WAVE Alert: Device dependent event handler
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-fieldset-missing-legend.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-fieldset-missing-legend.md
@@ -1,4 +1,4 @@
-# Alert - Fieldset missing legend
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/legend_missing.svg" /> Alert - Fieldset missing legend
 - WAVE Category: Alert
 - WAVE Alert: Fieldset missing legend
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-flash.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-flash.md
@@ -1,4 +1,4 @@
-# Alert - Flash
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/flash.svg" /> Alert - Flash
 - WAVE Category: Alert
 - WAVE Alert: Flash
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-html5-video-or-audio.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-html5-video-or-audio.md
@@ -1,4 +1,4 @@
-# Alert - HTML5 video or audio
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/html5_video_audio.svg" /> Alert - HTML5 video or audio
 - WAVE Category: Alert
 - WAVE Alert: HTML5 video or audio
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-image-with-title.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-image-with-title.md
@@ -1,4 +1,4 @@
-# Alert- Image with title
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/image_title.svg" /> Alert- Image with title
 - WAVE Category: Alert
 - WAVE Alert: Image with title
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-java-applet.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-java-applet.md
@@ -1,4 +1,4 @@
-# Alert - Java applet
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/applet.svg" /> Alert - Java applet
 - WAVE Category: Alert
 - WAVE Alert: Java applet
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-javascript-jump-menu.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-javascript-jump-menu.md
@@ -1,4 +1,4 @@
-# Alert - JavaScript jump menu
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/javascript_jumpmenu.svg" /> Alert - JavaScript jump menu
 - WAVE Category: Alert
 - WAVE Alert: JavaScript jump menu
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-justified-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-justified-text.md
@@ -1,4 +1,4 @@
-# Alert - Justified text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/text_justified.svg" /> Alert - Justified text
 - WAVE Category: Alert
 - WAVE Alert: Justified text
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-layout-table.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-layout-table.md
@@ -1,4 +1,4 @@
-# Alert - Layout table
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/table_layout.svg" /> Alert - Layout table
 
 - WAVE Category: Alert
 - WAVE Alert: Layout table

--- a/docs/known-issues-and-solutions/solutions-index/alert-link-to-document.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-link-to-document.md
@@ -1,4 +1,4 @@
-# Alert - Link to document
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_document.svg" /> Alert - Link to document
 - WAVE Category: Alert
 - WAVE Alert: Link to document
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-link-to-excel-spreadsheet.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-link-to-excel-spreadsheet.md
@@ -1,4 +1,4 @@
-# Alert - Link to Excel spreadsheet
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_excel.svg" /> Alert - Link to Excel spreadsheet
 - WAVE Category: Alert
 - WAVE Alert: Link to Excel spreadsheet
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-link-to-pdf-document.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-link-to-pdf-document.md
@@ -1,4 +1,4 @@
-# Alert - Link to PDF document
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_pdf.svg" /> Alert - Link to PDF document
 - WAVE Category: Alert
 - WAVE Alert: Link to PDF document
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-link-to-powerpoint-document.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-link-to-powerpoint-document.md
@@ -1,4 +1,4 @@
-# Alert - Link to PowerPoint document
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_powerpoint.svg" /> Alert - Link to PowerPoint document
 - WAVE Category: Alert
 - WAVE Alert: Link to PowerPoint document
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-link-to-word-document.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-link-to-word-document.md
@@ -1,4 +1,4 @@
-# Alert - Link to Word document
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_word.svg" /> Alert - Link to Word document
 - WAVE Category: Alert
 - WAVE Alert: Link to Word document
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-long-alternative-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-long-alternative-text.md
@@ -1,4 +1,4 @@
-# Alert - Long alternative text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/alt_long.svg" /> Alert - Long alternative text
 - WAVE Category: Alert
 - WAVE Alert: Long alternative text
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-long-description.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-long-description.md
@@ -1,4 +1,4 @@
-# Alert - Long description
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/longdesc.svg" /> Alert - Long description
 - WAVE Category: Alert
 - WAVE Alert: Long description
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-missing-fieldset.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-missing-fieldset.md
@@ -1,4 +1,4 @@
-# Alert - Missing fieldset
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/fieldset_missing.svg" /> Alert - Missing fieldset
 - WAVE Category: Alert
 - WAVE Alert: Missing fieldset
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-missing-first-level-heading.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-missing-first-level-heading.md
@@ -1,4 +1,4 @@
-# Alert - Missing first level heading
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/h1_missing.svg" /> Alert - Missing first level heading
 - WAVE Category: Alert
 - WAVE Alert: Missing first level heading
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-no-heading-structure.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-no-heading-structure.md
@@ -1,4 +1,4 @@
-# Alert - No heading structure
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/heading_missing.svg" /> Alert - No heading structure
 - WAVE Category: Alert
 - WAVE Alert: No heading structure
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-no-page-regions.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-no-page-regions.md
@@ -1,4 +1,4 @@
-# Alert - No page regions
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/region_missing.svg" /> Alert - No page regions
 - WAVE Category: Alert
 - WAVE Alert: No page regions
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-noscript-element.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-noscript-element.md
@@ -1,4 +1,4 @@
-# Alert - Noscript element
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/noscript.svg" /> Alert - Noscript element
 - WAVE Category: Alert
 - WAVE Alert: Noscript element
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-orphaned-form-label.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-orphaned-form-label.md
@@ -1,4 +1,4 @@
-# Alert - Orphaned form label
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/label_orphaned.svg" /> Alert - Orphaned form label
 - WAVE Category: Alert
 - WAVE Alert: Orphaned form label
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-plugin.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-plugin.md
@@ -1,4 +1,4 @@
-# Alert - Plugin
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/plugin.svg" /> Alert - Plugin
 - WAVE Category: Alert
 - WAVE Alert: Plugin
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-possible-heading.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-possible-heading.md
@@ -1,4 +1,4 @@
-# Alert - Possible heading
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/heading_possible.svg" /> Alert - Possible heading
 - WAVE Category: Alert
 - WAVE Alert: Possible heading
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-possible-list.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-possible-list.md
@@ -1,4 +1,4 @@
-# Alert - Possible list
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/list_possible.svg" /> Alert - Possible list
 - WAVE Category: Alert
 - WAVE Alert: Possible list
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-possible-table-caption.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-possible-table-caption.md
@@ -1,4 +1,4 @@
-# Alert - Possible table caption
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/table_caption_possible.svg" /> Alert - Possible table caption
 - WAVE Category: Alert
 - WAVE Alert: Possible table caption
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-redundant-alternative-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-redundant-alternative-text.md
@@ -1,4 +1,4 @@
-# Alert - Redundant alternative text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/alt_redundant.svg" /> Alert - Redundant alternative text
 - WAVE Category: Alert
 - WAVE Alert: Redundant alternative text
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-redundant-link.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-redundant-link.md
@@ -1,4 +1,4 @@
-# Alert - Redundant link
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_redundant.svg" /> Alert - Redundant link
 - WAVE Category: Alert
 - WAVE Alert: Redundant link
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-redundant-title-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-redundant-title-text.md
@@ -1,4 +1,4 @@
-# Alert - Redundant title text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/title_redundant.svg" /> Alert - Redundant title text
 - WAVE Category: Alert
 - WAVE Alert: Redundant title text
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-select-missing-label.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-select-missing-label.md
@@ -1,4 +1,4 @@
-# Alert - Select missing label
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/select_missing_label.svg" /> Alert - Select missing label
 - WAVE Category: Alert
 - WAVE Alert: Select missing label
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-skipped-heading-level.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-skipped-heading-level.md
@@ -1,4 +1,4 @@
-# Alert - Skipped heading level
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/heading_skipped.svg" /> Alert - Skipped heading level
 - WAVE Category: Alert
 - WAVE Alert: Skipped heading level
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-suspicious-alternative-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-suspicious-alternative-text.md
@@ -1,4 +1,4 @@
-# Alert - Suspicious alternative text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/alt_suspicious.svg" /> Alert - Suspicious alternative text
 - WAVE Category: Alert
 - WAVE Alert: Suspicious alternative text
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-suspicious-link-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-suspicious-link-text.md
@@ -1,4 +1,4 @@
-# Alert - Suspicious link text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_suspicious.svg" /> Alert - Suspicious link text
 - WAVE Category: Alert
 - WAVE Alert: Suspicious link text
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-tabindex.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-tabindex.md
@@ -1,4 +1,4 @@
-# Alert - Tabindex
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/tabindex.svg" /> Alert - Tabindex
 - WAVE Category: Alert
 - WAVE Alert: Tabindex
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-underlined-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-underlined-text.md
@@ -1,4 +1,4 @@
-# Alert - Underlined text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/underline.svg" /> Alert - Underlined text
 - WAVE Category: Alert
 - WAVE Alert: Underlined text
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-unlabeled-form-control-with-title.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-unlabeled-form-control-with-title.md
@@ -1,4 +1,4 @@
-# Alert - Unlabeled form control with title
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/label_title.svg" /> Alert - Unlabeled form control with title
 - WAVE Category: Alert
 - WAVE Alert: Unlabeled form control with title
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-very-small-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-very-small-text.md
@@ -1,4 +1,4 @@
-# Alert - Very small text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/text_small.svg" /> Alert - Very small text
 - WAVE Category: Alert
 - WAVE Alert: Very small text
 

--- a/docs/known-issues-and-solutions/solutions-index/alert-youtube-video.md
+++ b/docs/known-issues-and-solutions/solutions-index/alert-youtube-video.md
@@ -1,4 +1,4 @@
-# Alert - YouTube video
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/youtube_video.svg" /> Alert - YouTube video
 - WAVE Category: Alert
 - WAVE Alert: YouTube video
 

--- a/docs/known-issues-and-solutions/solutions-index/contrast-error-very-low-contrast.md
+++ b/docs/known-issues-and-solutions/solutions-index/contrast-error-very-low-contrast.md
@@ -1,4 +1,4 @@
-# Contrast Error - Very low contrast
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/contrast.svg" /> Contrast Error - Very low contrast
 - WAVE Category: Contrast Error
 - WAVE Contrast Error: Very low contrast
 

--- a/docs/known-issues-and-solutions/solutions-index/error-blinking-content.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-blinking-content.md
@@ -1,4 +1,4 @@
-# Error - Blinking content
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/blink.svg" /> Error - Blinking content
 - WAVE Category: Error
 - WAVE Error: Blinking content
 

--- a/docs/known-issues-and-solutions/solutions-index/error-broken-aria-menu.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-broken-aria-menu.md
@@ -1,4 +1,4 @@
-# Error - Broken ARIA menu
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/aria_menu_broken.svg" /> Error - Broken ARIA menu
 - WAVE Category: Error
 - WAVE Error: Broken ARIA menu
 

--- a/docs/known-issues-and-solutions/solutions-index/error-broken-aria-reference.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-broken-aria-reference.md
@@ -1,4 +1,4 @@
-# Error - Broken ARIA reference
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/aria_reference_broken.svg" /> Error - Broken ARIA reference
 - WAVE Category: Error
 - WAVE Error: Broken ARIA reference
 

--- a/docs/known-issues-and-solutions/solutions-index/error-broken-skip-link.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-broken-skip-link.md
@@ -1,4 +1,4 @@
-# Error - Broken skip link
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_skip_broken.svg" /> Error - Broken skip link
 - WAVE Category: Error
 - WAVE Error: Broken skip link
 

--- a/docs/known-issues-and-solutions/solutions-index/error-empty-form-label.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-empty-form-label.md
@@ -1,4 +1,4 @@
-# Error - Empty form label
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/label_empty.svg" /> Error - Empty form label
 - WAVE Category: Error
 - WAVE Error: Empty form label
 

--- a/docs/known-issues-and-solutions/solutions-index/error-empty-heading.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-empty-heading.md
@@ -1,4 +1,4 @@
-# Error - Empty heading
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/heading_empty.svg" /> Error - Empty heading
 - WAVE Category: Error
 - WAVE Error: Empty heading
 

--- a/docs/known-issues-and-solutions/solutions-index/error-empty-link.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-empty-link.md
@@ -1,4 +1,4 @@
-# Error - Empty link
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/link_empty.svg" /> Error - Empty link
 - WAVE Category: Error
 - WAVE Error: Empty link
 

--- a/docs/known-issues-and-solutions/solutions-index/error-empty-table-header.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-empty-table-header.md
@@ -1,4 +1,4 @@
-# Error - Empty Table Header
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/th_empty.svg" /> Error - Empty Table Header
 - WAVE Category: Error
 - WAVE Error: Empty Table Header
 

--- a/docs/known-issues-and-solutions/solutions-index/error-image-button-missing-alternative-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-image-button-missing-alternative-text.md
@@ -1,4 +1,4 @@
-# Error - Image button missing alternative text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/alt_input_missing.svg" /> Error - Image button missing alternative text
 - WAVE Category: Error
 - WAVE Error: Image button missing alternative text
 

--- a/docs/known-issues-and-solutions/solutions-index/error-image-map-area-missing-alternative-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-image-map-area-missing-alternative-text.md
@@ -1,4 +1,4 @@
-# Error - Image map area missing alternative text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/alt_area_missing.svg" /> Error - Image map area missing alternative text
 - WAVE Category: Error
 - WAVE Error: Image map area missing alternative text
 

--- a/docs/known-issues-and-solutions/solutions-index/error-image-map-missing-alternative-text.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-image-map-missing-alternative-text.md
@@ -1,4 +1,4 @@
-# Error - Image map missing alternative text
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/alt_map_missing.svg" /> Error - Image map missing alternative text
 - WAVE Category: Error
 - WAVE Error: Image map missing alternative text
 

--- a/docs/known-issues-and-solutions/solutions-index/error-invalid-longdesc.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-invalid-longdesc.md
@@ -1,4 +1,4 @@
-# Error - Invalid longdesc
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/longdesc_invalid.svg" /> Error - Invalid longdesc
 - WAVE Category: Error
 - WAVE Error: Invalid longdesc
 

--- a/docs/known-issues-and-solutions/solutions-index/error-language-missing-or-invalid.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-language-missing-or-invalid.md
@@ -1,4 +1,4 @@
-# Error - Language missing or invalid
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/language_missing.svg" /> Error - Language missing or invalid
 - WAVE Category: Error
 - WAVE Error: Language missing or invalid
 

--- a/docs/known-issues-and-solutions/solutions-index/error-marquee.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-marquee.md
@@ -1,4 +1,4 @@
-# Error - Marquee
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/marquee.svg" /> Error - Marquee
 - WAVE Category: Error
 - WAVE Error: Marquee
 

--- a/docs/known-issues-and-solutions/solutions-index/error-missing-form-label.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-missing-form-label.md
@@ -1,4 +1,4 @@
-# Error - Missing Form Label
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/label_missing.svg" /> Error - Missing Form Label
 - WAVE Category: Error
 - WAVE Error: Missing Form Label
 

--- a/docs/known-issues-and-solutions/solutions-index/error-missing-or-uninformative-page-title.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-missing-or-uninformative-page-title.md
@@ -1,4 +1,4 @@
-# Error - Missing or uninformative page title
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/title_invalid.svg" /> Error - Missing or uninformative page title
 - WAVE Category: Error
 - WAVE Error: Missing or uninformative page title
 

--- a/docs/known-issues-and-solutions/solutions-index/error-multiple-form-labels.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-multiple-form-labels.md
@@ -1,4 +1,4 @@
-# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/label_multiple.svg" /> Error - Multiple form labels
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/longdesc_invalid.svg" /> Error - Multiple form labels
 - WAVE Category: Error
 - WAVE Error: Multiple form labels
 
@@ -17,7 +17,7 @@ WAVE Tool's Reference material on Multiple form labels may not specifically addr
 
 ??? Info "Click to see WAVE Tool Reference"
 
-    This content added 2026-04-09. Check for updated guidance at: <a href="https://wave.webaim.org/api/docs?format=html#label_multiple" target="_blank">https://wave.webaim.org/api/docs?format=html#label_multiple</a>
+    This content added 2026-04-09. Check for updated guidance at: <a href="https://wave.webaim.org/api/docs?format=html#longdesc_invalid" target="_blank">https://wave.webaim.org/api/docs?format=html#longdesc_invalid</a>
 
     > ### WAVE Category
     > Errors

--- a/docs/known-issues-and-solutions/solutions-index/error-multiple-form-labels.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-multiple-form-labels.md
@@ -1,4 +1,4 @@
-# Error - Multiple form labels
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/label_multiple.svg" /> Error - Multiple form labels
 - WAVE Category: Error
 - WAVE Error: Multiple form labels
 
@@ -17,7 +17,7 @@ WAVE Tool's Reference material on Multiple form labels may not specifically addr
 
 ??? Info "Click to see WAVE Tool Reference"
 
-    This content added 2026-04-09. Check for updated guidance at: <a href="https://wave.webaim.org/api/docs?format=html#longdesc_invalid" target="_blank">https://wave.webaim.org/api/docs?format=html#longdesc_invalid</a>
+    This content added 2026-04-09. Check for updated guidance at: <a href="https://wave.webaim.org/api/docs?format=html#label_multiple" target="_blank">https://wave.webaim.org/api/docs?format=html#label_multiple</a>
 
     > ### WAVE Category
     > Errors

--- a/docs/known-issues-and-solutions/solutions-index/error-multiple-form-labels.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-multiple-form-labels.md
@@ -1,4 +1,4 @@
-# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/longdesc_invalid.svg" /> Error - Multiple form labels
+# Error - Multiple form labels
 - WAVE Category: Error
 - WAVE Error: Multiple form labels
 

--- a/docs/known-issues-and-solutions/solutions-index/error-page-refreshes-or-redirects.md
+++ b/docs/known-issues-and-solutions/solutions-index/error-page-refreshes-or-redirects.md
@@ -1,4 +1,4 @@
-# Error - Page refreshes or redirects
+# <img width="44" height="44" alt="" src="https://wave.webaim.org/img/icons/meta_refresh.svg" /> Error - Page refreshes or redirects
 - WAVE Category: Error
 - WAVE Error: Page refreshes or redirects
 


### PR DESCRIPTION
## Overview

WAVE displays a distinct icon for each accessibility finding. Adding the same icons to the solution index pages helps developers visually match a finding from a WAVE accessibility review with the corresponding guidance page in this repository.

## Changes made

- Added the matching WAVE icon to the H1 heading on 60 solution index pages that did not already have one.
- Kept the icons at 44 by 44 pixels to match the existing Empty Button example.
- Used empty alternative text because the icons are decorative and the adjacent heading already identifies each finding.
- Left the custom Screen Reader Only Class page without an icon because it has no WAVE reference or matching WAVE icon.
- Left the Multiple form labels page without an icon because its WAVE reference mismatch is being handled separately.

## Why

Using the same visual language as the WAVE evaluation tool makes it easier for developers to recognize a reported accessibility problem and confirm that they have opened the correct solution page.

## Validation

- Confirmed all 60 newly referenced WAVE SVGs return HTTP 200.
- Confirmed 61 of the 63 non-index solution pages now have an icon; the two exceptions are Screen Reader Only Class and Multiple form labels.
- Successfully built the documentation with MkDocs.

Related to #66.