### PR TITLE
Update index.md

### DIFF
--- a/docs/known-issues-and-solutions/solutions-index/index.md
+++ b/docs/known-issues-and-solutions/solutions-index/index.md
@@ -63,9 +63,9 @@ Error | [Broken skip link](error-broken-skip-link.md) | missing | missing | miss
 Error | [Empty form label](error-empty-form-label.md) | missing | missing | missing | missing | missing
 Error | [Empty heading](error-empty-heading.md) | missing | missing | missing | missing | missing
 Error | [Empty link](error-empty-link.md) | missing | missing | missing | missing | missing
-Error | [Error Broken ARIA reference](error-error-broken-aria-reference.md) | TRUE | TRUE | TRUE | TRUE | TRUE
-Error | [Error Empty Button](error-error-empty-button.md) | TRUE | TRUE | TRUE | TRUE | TRUE
-Error | [Error Empty Table Header](error-error-empty-table-header.md) | TRUE | TRUE | TRUE | TRUE | TRUE
+Error | [Error Broken ARIA reference](error-broken-aria-reference.md) | TRUE | TRUE | TRUE | TRUE | TRUE
+Error | [Error Empty Button](error-empty-button.md) | TRUE | TRUE | TRUE | TRUE | TRUE
+Error | [Error Empty Table Header](error-empty-table-header.md) | TRUE | TRUE | TRUE | TRUE | TRUE
 Error | [Image button missing alternative text](error-image-button-missing-alternative-text.md) | missing | missing | missing | missing | missing
 Error | [Image map area missing alternative text](error-image-map-area-missing-alternative-text.md) | missing | missing | missing | missing | missing
 Error | [Image map missing alternative text](error-image-map-missing-alternative-text).md | missing | missing | missing | missing | missing

--- a/docs/known-issues-and-solutions/solutions-index/index.md
+++ b/docs/known-issues-and-solutions/solutions-index/index.md
@@ -63,9 +63,9 @@ Error | [Broken skip link](error-broken-skip-link.md) | missing | missing | miss
 Error | [Empty form label](error-empty-form-label.md) | missing | missing | missing | missing | missing
 Error | [Empty heading](error-empty-heading.md) | missing | missing | missing | missing | missing
 Error | [Empty link](error-empty-link.md) | missing | missing | missing | missing | missing
-Error | [Error Broken ARIA reference](error-broken-aria-reference.md) | TRUE | TRUE | TRUE | TRUE | TRUE
-Error | [Error Empty Button](error-empty-button.md) | TRUE | TRUE | TRUE | TRUE | TRUE
-Error | [Error Empty Table Header](error-empty-table-header.md) | TRUE | TRUE | TRUE | TRUE | TRUE
+Error | [Broken ARIA reference](error-broken-aria-reference.md) | TRUE | TRUE | TRUE | TRUE | TRUE
+Error | [Empty Button](error-empty-button.md) | TRUE | TRUE | TRUE | TRUE | TRUE
+Error | [Empty Table Header](error-empty-table-header.md) | TRUE | TRUE | TRUE | TRUE | TRUE
 Error | [Image button missing alternative text](error-image-button-missing-alternative-text.md) | missing | missing | missing | missing | missing
 Error | [Image map area missing alternative text](error-image-map-area-missing-alternative-text.md) | missing | missing | missing | missing | missing
 Error | [Image map missing alternative text](error-image-map-missing-alternative-text).md | missing | missing | missing | missing | missing


### PR DESCRIPTION
### Issue
- https://github.com/hackforla/accessibility/issues/66#issuecomment-5139887504

### Change Made
- Updated three links to remove redundant "error"

#### Before
`Error | [Error Broken ARIA reference](error-error-broken-aria-reference.md) | TRUE | TRUE | TRUE | TRUE | TRUE`
`Error | [Error Empty Button](error-error-empty-button.md) | TRUE | TRUE | TRUE | TRUE | TRUE`
`Error | [Error Empty Table Header](error-error-empty-table-header.md) | TRUE | TRUE | TRUE | TRUE | TRUE`

#### After
`Error | [Error Broken ARIA reference](error-broken-aria-reference.md) | TRUE | TRUE | TRUE | TRUE | TRUE`
`Error | [Error Empty Button](error-empty-button.md) | TRUE | TRUE | TRUE | TRUE | TRUE`
`Error | [Error Empty Table Header](error-empty-table-header.md) | TRUE | TRUE | TRUE | TRUE | TRUE`

### Why
- The URL link referenced a page that did not exist

### Additional Info
- Also changed spreadsheet rows 51 - 53 to fix where the problem originated in [Accessibility: WAVE: Known Issues and Solutions DRAFTS](https://docs.google.com/spreadsheets/d/14cXbfsc2McDpKxmGyXbLPkCgj1aeN7NmlxzeeJqlcsU)